### PR TITLE
copr_build.py: on failure, mention that copr build credentials expire.

### DIFF
--- a/cloud-init/copr_build.py
+++ b/cloud-init/copr_build.py
@@ -19,6 +19,8 @@ ID_CLOUD_INIT_DEV = 14567
 TEST_CHROOTS = ['epel-6-x86_64', 'epel-7-x86_64']
 URL_COPR = "https://copr.fedorainfracloud.org/coprs/g/cloud-init"
 
+DEFAULT_COPR_CONF = os.path.expanduser('~/.config/copr')
+
 
 def check_test_chroot(tasks):
     """Checks the status of specific chroots for testing."""
@@ -78,7 +80,25 @@ def launch_build(project, srpm):
     return build
 
 
-def main(srpm, copr_conf=None, dev=None):
+def mention_expiration_on_creds(conf_file):
+    exp_lines = []
+    print("******** Copr API creds in '%s' *do* expire ********" % conf_file)
+    print("******** Get new creds at %s ********" %
+          "https://copr.fedorainfracloud.org/api/")
+    try:
+        with open(conf_file, "r") as fp:
+            contents = fp.read()
+        exp_lines = [l for l in contents.splitlines()
+                     if 'expiration' in l]
+    except FileNotFoundError:
+        print("Did not find creds file: %s" % copr_conf)
+
+    if exp_lines:
+        print("From your config:")
+        print(''.join(["  %s\n" % l for l in exp_lines]))
+
+
+def main(srpm, copr_conf=DEFAULT_COPR_CONF, dev=None):
     """Query COPR info."""
     if not os.path.isfile(srpm):
         print("Error: The given SRPM is not a file:\n%s" % srpm)
@@ -89,7 +109,11 @@ def main(srpm, copr_conf=None, dev=None):
     project = client.projects.get_one(project_id)
 
     print(datetime.datetime.now())
-    build = launch_build(project, srpm)
+    try:
+        build = launch_build(project, srpm)
+    except Exception as e:
+        mention_expiration_on_creds(copr_conf)
+        raise e
     tasks = get_build_tasks(build)
     check_build_status(build, tasks)
     check_test_chroot(tasks)
@@ -100,7 +124,8 @@ def main(srpm, copr_conf=None, dev=None):
 if __name__ == '__main__':
     ARGPARSER = argparse.ArgumentParser(description='cloud-init copr script')
     ARGPARSER.add_argument('-c', '--config', dest='copr_conf', action='store',
-                           help='copr config file location')
+                           help='copr config file location',
+                           default=DEFAULT_COPR_CONF)
     ARGPARSER.add_argument('-d', '--dev', dest='dev', action='store_true',
                            help='use cloud-init-dev instead of cloud-init')
     ARGPARSER.add_argument('-s', '--srpm', dest='srpm', action='store',


### PR DESCRIPTION
And hopefully show the dates which will make an error obvious.